### PR TITLE
Creada la enum sin fallos

### DIFF
--- a/src/AppForSEII2526.API/Data/ApplicationDbContext.cs
+++ b/src/AppForSEII2526.API/Data/ApplicationDbContext.cs
@@ -20,9 +20,6 @@ public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options
     public DbSet<TarjetaCredito> TarjetasCredito { get; set; }
     public DbSet<Paypal> Paypals { get; set; }
 
-    public DbSet<DirigidaOferta> DirigidasOfertas { get; set; }
-    public DbSet<Cliente> Clientes { get; set; }
-    public DbSet<Socio> Socios { get; set; }
 
 
     protected override void OnModelCreating(ModelBuilder builder)

--- a/src/AppForSEII2526.API/Models/Cliente.cs
+++ b/src/AppForSEII2526.API/Models/Cliente.cs
@@ -1,6 +1,0 @@
-﻿namespace AppForSEII2526.API.Models
-{
-    public class Cliente : DirigidaOferta
-    {
-    }
-}

--- a/src/AppForSEII2526.API/Models/DirigidaOferta.cs
+++ b/src/AppForSEII2526.API/Models/DirigidaOferta.cs
@@ -1,8 +1,0 @@
-﻿namespace AppForSEII2526.API.Models
-{
-    public abstract class DirigidaOferta
-    {
-        [Key]
-        public int Id { get; set; }
-    }
-}

--- a/src/AppForSEII2526.API/Models/Oferta.cs
+++ b/src/AppForSEII2526.API/Models/Oferta.cs
@@ -22,6 +22,8 @@ namespace AppForSEII2526.API.Models
         [DisplayFormat(DataFormatString = "{0:dd/MM/yyyy}", ApplyFormatInEditMode = true)]
         public DateTime FechaOferta { get; set; }
 
+        public tipoDirigidaOferta ?TipoDirigida { get; set; }
+
         public List<OfertaItem> Items { get; set; }
 
 

--- a/src/AppForSEII2526.API/Models/Socio.cs
+++ b/src/AppForSEII2526.API/Models/Socio.cs
@@ -1,6 +1,0 @@
-﻿namespace AppForSEII2526.API.Models
-{
-    public class Socio : DirigidaOferta
-    {
-    }
-}

--- a/src/AppForSEII2526.API/Models/tipoOferta.cs
+++ b/src/AppForSEII2526.API/Models/tipoOferta.cs
@@ -1,0 +1,8 @@
+﻿namespace AppForSEII2526.API.Models
+{
+    public enum tipoDirigidaOferta
+    {
+        Socio,
+        Cliente
+    }
+}


### PR DESCRIPTION
Se ha eliminado la relacion de herencia entre tiposDirigidOferta con las clases Cliente y Socio para crear una enum y colocar un atributo opcional en la clase Oferta, de acuerdo a la descripcion del CU3