### PR TITLE
Arreglado los errores del sprint 2

### DIFF
--- a/src/AppForSEII2526.API/Controllers/OfertasController.cs
+++ b/src/AppForSEII2526.API/Controllers/OfertasController.cs
@@ -106,11 +106,19 @@ namespace AppForSEII2526.API.Controllers
                 ModelState.AddModelError(nameof(crearOfertaDTO.MetodoPagoId), $"El MetodoPagoId {crearOfertaDTO.MetodoPagoId} no existe.");
 
             // b. Validar Enum de TipoDirigida (si se proporcionó)
-            tipoDirigidaOferta tipoDirigido = tipoDirigidaOferta.Cliente; // Valor por defecto (asumiendo que Clientes es tu "todo el mundo")
+            tipoDirigidaOferta? tipoDirigido = null;
             if (!string.IsNullOrEmpty(crearOfertaDTO.TipoDirigida))
             {
-                if (!Enum.TryParse<tipoDirigidaOferta>(crearOfertaDTO.TipoDirigida, true, out tipoDirigido))
-                    ModelState.AddModelError(nameof(crearOfertaDTO.TipoDirigida), $"El valor '{crearOfertaDTO.TipoDirigida}' no es válido. Use 'Socio' o 'Cliente'.");
+                // Solo intentamos parsear si el usuario escribió algo
+                if (Enum.TryParse<tipoDirigidaOferta>(crearOfertaDTO.TipoDirigida, true, out var result))
+                {
+                    tipoDirigido = result;
+                }
+                else
+                {
+                    // Si escribió algo pero no coincide con los valores del Enum
+                    ModelState.AddModelError(nameof(crearOfertaDTO.TipoDirigida), $"El valor '{crearOfertaDTO.TipoDirigida}' no es válido. Use 'Socio', 'Cliente' o déjelo vacío.");
+                }
             }
 
             //c. Validar Usuario

--- a/src/AppForSEII2526.API/DTOs/CrearOfertaDTO.cs
+++ b/src/AppForSEII2526.API/DTOs/CrearOfertaDTO.cs
@@ -15,6 +15,20 @@
             Items = new List<CrearOfertaItemDTO>();
         }
 
+        public override bool Equals(object? obj)
+        {
+            return obj is CrearOfertaDTO dTO &&
+                   FechaInicio.Equals(dTO.FechaInicio) &&
+                   FechaFinal.Equals(dTO.FechaFinal) &&
+                   TipoDirigida == dTO.TipoDirigida &&
+                   MetodoPagoId == dTO.MetodoPagoId &&
+                   nombreUsuario == dTO.nombreUsuario &&
+                   EqualityComparer<List<CrearOfertaItemDTO>>.Default.Equals(Items, dTO.Items);
+        }
 
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(FechaInicio, FechaFinal, TipoDirigida, MetodoPagoId, nombreUsuario, Items);
+        }
     }
 }

--- a/src/AppForSEII2526.API/DTOs/CrearOfertaItemDTO.cs
+++ b/src/AppForSEII2526.API/DTOs/CrearOfertaItemDTO.cs
@@ -1,4 +1,5 @@
-﻿namespace AppForSEII2526.API.DTOs
+﻿
+namespace AppForSEII2526.API.DTOs
 {
     public class CrearOfertaItemDTO
     {
@@ -7,5 +8,17 @@
 
         // El porcentaje de descuento (p.ej., 20 para un 20%)
         public int PorcentajeDescuento { get; set; }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is CrearOfertaItemDTO dTO &&
+                   HerramientaId == dTO.HerramientaId &&
+                   PorcentajeDescuento == dTO.PorcentajeDescuento;
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(HerramientaId, PorcentajeDescuento);
+        }
     }
 }

--- a/test/AppForSEII2526.UT/OfertasController_test/GetDetalleParaOferta_test.cs
+++ b/test/AppForSEII2526.UT/OfertasController_test/GetDetalleParaOferta_test.cs
@@ -90,15 +90,17 @@ namespace AppForSEII2526.UT.OfertasController_test
             ILogger<OfertasController> logger = mock.Object;
             var controller = new OfertasController(_context, logger);
 
+            // Creamos el objeto que ESPERAMOS recibir.
             var expectedOferta = new OfertasParaDetalleDTO(
-                DateOnly.FromDateTime(DateTime.UtcNow.AddDays(30)),
-                DateOnly.FromDateTime(DateTime.UtcNow),
-                DateOnly.FromDateTime(DateTime.UtcNow),
+                DateOnly.FromDateTime(DateTime.UtcNow.AddDays(30)), // Fecha Final
+                DateOnly.FromDateTime(DateTime.UtcNow),             // Fecha Inicio
+                DateOnly.FromDateTime(DateTime.UtcNow),             // Fecha Oferta
                 "Cliente",
                 "Efectivo",
                 new List<OfertaItemsDTO>(),
                 "Jesus"
             );
+
             expectedOferta.Items.Add(new OfertaItemsDTO
             (
                 "Martillo",
@@ -112,34 +114,14 @@ namespace AppForSEII2526.UT.OfertasController_test
             var result = await controller.GetDetalleHerramientasParaOferta(1);
 
             //Assert 
-            // 1. Comprueba que los objetos no sean nulos
+
+            // 1. Verificaciones básicas de que la respuesta HTTP es correcta
             Assert.NotNull(result);
-
             var okResult = Assert.IsType<OkObjectResult>(result);
-
             var ofertaDTOActual = Assert.IsType<OfertasParaDetalleDTO>(okResult.Value);
 
-            // 2. Comprueba las propiedades simples (string, DateOnly, int, etc.)
-            Assert.Equal(expectedOferta.FechaFinal, ofertaDTOActual.FechaFinal);
-            Assert.Equal(expectedOferta.FechaInicio, ofertaDTOActual.FechaInicio);
-            Assert.Equal(expectedOferta.TipoDirigida, ofertaDTOActual.TipoDirigida);
-            Assert.Equal(expectedOferta.MetodoPago, ofertaDTOActual.MetodoPago);
-            Assert.Equal(expectedOferta.nombreUsuario, ofertaDTOActual.nombreUsuario);
 
-            // 3. Comprueba las listas o colecciones
-            //    Primero, comprueba que tengan el mismo número de elementos
-            Assert.Equal(expectedOferta.Items.Count, ofertaDTOActual.Items.Count);
-
-            // 4. Comprueba los elementos DENTRO de las listas
-            //    (En este test, sabes que solo hay un item, en la posición [0])
-            var expectedItem = expectedOferta.Items[0];
-            var actualItem = ofertaDTOActual.Items[0];
-
-            Assert.Equal(expectedItem.NombreHerramienta, actualItem.NombreHerramienta);
-            Assert.Equal(expectedItem.MaterialHerramienta, actualItem.MaterialHerramienta);
-            Assert.Equal(expectedItem.FabricanteHerramienta, actualItem.FabricanteHerramienta);
-            Assert.Equal(expectedItem.PrecioHerramienta, actualItem.PrecioHerramienta);
-            Assert.Equal(expectedItem.PrecioFinalOferta, actualItem.PrecioFinalOferta);
+            Assert.Equal(expectedOferta, ofertaDTOActual);
         }
     }
 }

--- a/test/AppForSEII2526.UT/OfertasController_test/Post_oferta_test.cs
+++ b/test/AppForSEII2526.UT/OfertasController_test/Post_oferta_test.cs
@@ -187,7 +187,7 @@ namespace AppForSEII2526.UT.OfertasController_test
                 new object[] { ofertaApplicationUser, "El usuario no existe." },
                 new object[] { ofertaNoDisponible, "La HerramientaId 999 no existe." },
                 new object[] { ofertaMetodoPagoInvalido, "El MetodoPagoId 999 no existe." },
-                new object[] { ofertaTipoInvalido, "El valor 'TipoRaro' no es válido. Use 'Socio' o 'Cliente'." },
+                new object[] { ofertaTipoInvalido, "El valor 'TipoRaro' no es válido. Use 'Socio', 'Cliente' o déjelo vacío."},
                 // El mensaje de error del porcentaje puede variar según el nombre de tu herramienta
                 new object[] { ofertaPorcentajeInvalido, "El porcentaje 91% para 'Herramienta1' no es válido. Debe estar entre 1 y 90." },
                 new object[] { ofertaPorcentajeCero, "El porcentaje 0% para 'Herramienta1' no es válido. Debe estar entre 1 y 90." },
@@ -225,80 +225,76 @@ namespace AppForSEII2526.UT.OfertasController_test
         [Trait("Database", "WithoutFixture")]
         public async Task Post_oferta_CrearOferta_Exitoso()
         {
-            // Arrange
+            // 1. ARRANGE
             var mock = new Mock<ILogger<OfertasController>>();
             ILogger<OfertasController> logger = mock.Object;
-
             var controller = new OfertasController(_context, logger);
 
+            // Datos de entrada (Input)
             var ofertaItems = new List<CrearOfertaItemDTO>
             {
                 new CrearOfertaItemDTO { HerramientaId = 1, PorcentajeDescuento = 10 },
                 new CrearOfertaItemDTO { HerramientaId = 2, PorcentajeDescuento = 15 }
             };
+
             var ofertaDTO = new CrearOfertaDTO
             {
                 FechaInicio = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(1)),
                 FechaFinal = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(30)),
                 TipoDirigida = "Cliente",
-                MetodoPagoId = 1,
+                MetodoPagoId = 1, // Corresponde a "Efectivo" según tu Seed
                 nombreUsuario = _nombreUsuario,
                 Items = ofertaItems
             };
 
-            // --- Pre-cálculo de precios esperados ---
-            // Herramienta 1: 10.0f * (1 - 0.10) = 9.0f
-            float expectedPrice1 = 9.0f;
-            // Herramienta 2: 15.7f * (1 - 0.15) = 13.345f
-            float expectedPrice2 = 13.345f;
+            // Construimos el objeto de RESPUESTA ESPERADA (Expected Output)
+            // Aquí definimos qué debería devolver el controlador si todo sale bien.
+            var expectedResponse = new OfertasParaDetalleDTO(
+                ofertaDTO.FechaFinal,
+                ofertaDTO.FechaInicio,
+                DateOnly.FromDateTime(DateTime.UtcNow), // Fecha de creación (hoy)
+                "Cliente",
+                "Efectivo",
+                new List<OfertaItemsDTO>(),
+                _nombreUsuario
+            );
 
-            // Act
+            // Añadimos los items calculados que esperamos recibir
+            // Item 1: Precio 10.0, Descuento 10% -> 9.0
+            expectedResponse.Items.Add(new OfertaItemsDTO(
+                _nombreHerramienta1, "Acero", _nombreFabricante1, 10.0f, 9.0f));
+
+            // Item 2: Precio 15.7, Descuento 15% -> 13.345
+            expectedResponse.Items.Add(new OfertaItemsDTO(
+                _nombreHerramienta2, "Madera", _nombreFabricante2, 15.7f, 13.345f));
+
+
+            // 2. ACT
             var result = await controller.CrearOferta(ofertaDTO);
 
 
-            // Assert
+            // 3. ASSERT (Respuesta HTTP)
             var createdAtActionResult = Assert.IsType<CreatedAtActionResult>(result);
-            var createdOfertaDTO = Assert.IsType<OfertasParaDetalleDTO>(createdAtActionResult.Value); 
+            var createdOfertaDTO = Assert.IsType<OfertasParaDetalleDTO>(createdAtActionResult.Value);
 
-            Assert.Equal(ofertaDTO.FechaInicio, createdOfertaDTO.FechaInicio);
-            Assert.Equal(ofertaDTO.FechaFinal, createdOfertaDTO.FechaFinal);
-            Assert.Equal(ofertaDTO.TipoDirigida, createdOfertaDTO.TipoDirigida);
-            Assert.Equal(ofertaDTO.Items.Count, createdOfertaDTO.Items.Count);
-            Assert.Equal(_nombreUsuario, createdOfertaDTO.nombreUsuario);
-            Assert.Equal("Efectivo", createdOfertaDTO.MetodoPago);
+            Assert.Equal(expectedResponse, createdOfertaDTO);
 
-            // --- 3. Comprobar los items del DTO (¡Importante!) ---
-            var item1DTO = createdOfertaDTO.Items.FirstOrDefault(i => i.NombreHerramienta == _nombreHerramienta1);
-            Assert.NotNull(item1DTO);
-            Assert.Equal(10.0f, item1DTO.PrecioHerramienta);
-            Assert.Equal(expectedPrice1, item1DTO.PrecioFinalOferta); // Comprueba el cálculo del descuento
 
-            var item2DTO = createdOfertaDTO.Items.FirstOrDefault(i => i.NombreHerramienta == _nombreHerramienta2);
-            Assert.NotNull(item2DTO);
-            Assert.Equal(15.7f, item2DTO.PrecioHerramienta);
-            Assert.Equal(expectedPrice2, item2DTO.PrecioFinalOferta); // Comprueba el cálculo del descuento
-
-            // --- 4. (¡EL MÁS IMPORTANTE!) Comprobar la Base de Datos ---
-            // Tu constructor ya creó la Oferta ID=1. Esta nueva debe ser la ID=2.
+            // 4. ASSERT (Base de Datos)
+            // no solo que el controlador devolvió el DTO correcto.
             var ofertaEnDB = await _context.Ofertas
-                                        .Include(o => o.Usuario)
-                                        .Include(o => o.MetodosPago)
-                                        .Include(o => o.Items)
-                                        .FirstOrDefaultAsync(o => o.Id == 2); // Busca la nueva oferta
+                                    .Include(o => o.Usuario)
+                                    .Include(o => o.MetodosPago)
+                                    .Include(o => o.Items)
+                                    .FirstOrDefaultAsync(o => o.Id == 2); // ID 2 porque la 1 se crea en el constructor
 
             Assert.NotNull(ofertaEnDB);
             Assert.Equal(ofertaDTO.FechaInicio, ofertaEnDB.FechaInicio);
-            Assert.Equal(_nombreUsuario, ofertaEnDB.Usuario.Nombre); // Comprueba el usuario enlazado
-            Assert.Equal("Efectivo", ofertaEnDB.MetodosPago.Nombre); // Comprueba el método de pago
-            Assert.Equal(2, ofertaEnDB.Items.Count); // Comprueba el número de items
+            Assert.Equal(2, ofertaEnDB.Items.Count);
 
-            // Comprobar que el precio final se guardó bien en la BBDD
-            var item1EnDB = ofertaEnDB.Items.FirstOrDefault(i => i.HerramientaId == 1);
-            Assert.NotNull(item1EnDB);
-            Assert.Equal(10, item1EnDB.Porcentaje);
-            Assert.Equal(expectedPrice1, item1EnDB.PrecioFinal);
-
-
+            // Verificamos un dato clave en BD (ej: precio final calculado guardado correctamente)
+            var itemDb = ofertaEnDB.Items.First(i => i.HerramientaId == 1);
+            Assert.Equal(9.0f, itemDb.PrecioFinal, 0.001f); // Usamos tolerancia para float
         }
     }
 }


### PR DESCRIPTION
- Se ha procedido a arreglar las pruebas para que usen el método equals
- Se ha arreglado el controlador y las pruebas para que el método post permita recibir una cadena vacía y registrar como null el tipo dirigida al que va la oferta