### PR TITLE
Arreglo de fallos del Sprint 2 del CU Reparaciones

### DIFF
--- a/src/AppForSEII2526.API/Controllers/HerramientasController.cs
+++ b/src/AppForSEII2526.API/Controllers/HerramientasController.cs
@@ -82,7 +82,7 @@ namespace AppForSEII2526.API.Controllers
         {
             var herramientas = await _context.Herramientas
                 .Include(h => h.Fabricante)
-                .Where(h => (filtroNombre == null || h.Fabricante.Nombre == filtroNombre) &&
+                .Where(h => (filtroNombre == null || h.Nombre == filtroNombre) &&
                     (filtroTiempoReparacion == null || h.TiempoReparacion <= filtroTiempoReparacion))
                 .Select(h => new HerramientasParaReparaciónDTO(
                     h.Nombre, h.Material, h.Fabricante.Nombre, h.Precio, h.TiempoReparacion))

--- a/src/AppForSEII2526.API/DTOs/CrearReparacionDTO.cs
+++ b/src/AppForSEII2526.API/DTOs/CrearReparacionDTO.cs
@@ -18,5 +18,23 @@
         {
             ReparacionesItems = new List<CrearReparacionItemDTO>();
         }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is CrearReparacionDTO dTO &&
+                   Nombre == dTO.Nombre &&
+                   Apellidos == dTO.Apellidos &&
+                   FechaEntrega.Equals(dTO.FechaEntrega) &&
+                   FechaRecogida.Equals(dTO.FechaRecogida) &&
+                   PrecioTotal == dTO.PrecioTotal &&
+                   MetodoPagoId == dTO.MetodoPagoId &&
+                   telefono == dTO.telefono &&
+                   EqualityComparer<List<CrearReparacionItemDTO>>.Default.Equals(ReparacionesItems, dTO.ReparacionesItems);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Nombre, Apellidos, FechaEntrega, FechaRecogida, PrecioTotal, MetodoPagoId, telefono, ReparacionesItems);
+        }
     }
 }

--- a/src/AppForSEII2526.API/DTOs/CrearReparacionItemDTO.cs
+++ b/src/AppForSEII2526.API/DTOs/CrearReparacionItemDTO.cs
@@ -1,4 +1,5 @@
-﻿namespace AppForSEII2526.API.DTOs
+﻿
+namespace AppForSEII2526.API.DTOs
 {
     public class CrearReparacionItemDTO
     {
@@ -7,5 +8,19 @@
 
       
         public int HerramientaCantidad { get; set; }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is CrearReparacionItemDTO dTO &&
+                   HerramientaId == dTO.HerramientaId &&
+                   HerramientaDescripcion == dTO.HerramientaDescripcion &&
+                   HerramientaCantidad == dTO.HerramientaCantidad;
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(HerramientaId, HerramientaDescripcion, HerramientaCantidad);
+        }
     }
+
 }

--- a/src/AppForSEII2526.API/DTOs/ReparacionesDTO.cs
+++ b/src/AppForSEII2526.API/DTOs/ReparacionesDTO.cs
@@ -38,7 +38,8 @@ namespace AppForSEII2526.API.DTOs
                    PrecioTotal == dTO.PrecioTotal &&
                    nombre == dTO.nombre &&
                    apellidos == dTO.apellidos &&
-                   EqualityComparer<IList<ReparacionesItemDTO>>.Default.Equals(ReparacionesItems, dTO.ReparacionesItems);
+                    (ReparacionesItems?.SequenceEqual(dTO.ReparacionesItems ?? new List<ReparacionesItemDTO>()) ??
+            dTO.ReparacionesItems == null);
         }
 
         public override int GetHashCode()

--- a/test/AppForSEII2526.UT/HerramientasController_test/GetHerramientasReparacion_test.cs
+++ b/test/AppForSEII2526.UT/HerramientasController_test/GetHerramientasReparacion_test.cs
@@ -53,7 +53,7 @@ namespace AppForSEII2526.UT.HerramientasController_test
             return new List<object[]>
             {
                 new object[] { null, null,  herramientasDTO_TC1 },
-                new object[] { "Utensilios y Más", null, herramientasDTO_TC2 },
+                new object[] { "Destornillador", null, herramientasDTO_TC2 },
                 new object[] { null, 5, herramientasDTO_TC3 }
             };
         }

--- a/test/AppForSEII2526.UT/ReparacionController_test/GetDetalleReparacion_test.cs
+++ b/test/AppForSEII2526.UT/ReparacionController_test/GetDetalleReparacion_test.cs
@@ -168,32 +168,9 @@ namespace AppForSEII2526.UT.ReparacionesController_test
             Assert.Single(reparacionesDTOList);
             var reparacionDTOActual = reparacionesDTOList[0];
 
-            // 4. Comprueba las propiedades simples (string, DateOnly, float, etc.)
-            //    Usamos el DTO esperado contra el DTO actual
-            Assert.Equal(expectedReparacion.nombre, reparacionDTOActual.nombre);
-            Assert.Equal(expectedReparacion.apellidos, reparacionDTOActual.apellidos);
-            Assert.Equal(expectedReparacion.FechaEntrega, reparacionDTOActual.FechaEntrega);
-            Assert.Equal(expectedReparacion.FechaRecogida, reparacionDTOActual.FechaRecogida);
-            Assert.Equal(expectedReparacion.PrecioTotal, reparacionDTOActual.PrecioTotal);
 
-            // 5. Comprueba las listas o colecciones (los items)
-            Assert.Equal(expectedReparacion.ReparacionesItems.Count, reparacionDTOActual.ReparacionesItems.Count);
+            Assert.Equal(expectedReparacion, reparacionDTOActual);
 
-            // 6. Comprueba los elementos DENTRO de las listas
-            //    Ordenamos por nombre para asegurar que el orden de BBDD no afecte al test
-            var expectedItems = expectedReparacion.ReparacionesItems.OrderBy(i => i.HerramientaNombre).ToList();
-            var actualItems = reparacionDTOActual.ReparacionesItems.OrderBy(i => i.HerramientaNombre).ToList();
-
-            // Comparamos item por item
-            Assert.Equal(expectedItems[0].HerramientaNombre, actualItems[0].HerramientaNombre);
-            Assert.Equal(expectedItems[0].HerramientaDescripcion, actualItems[0].HerramientaDescripcion);
-            Assert.Equal(expectedItems[0].HerramientaCantidad, actualItems[0].HerramientaCantidad);
-            Assert.Equal(expectedItems[0].HerramientaPrecio, actualItems[0].HerramientaPrecio);
-
-            Assert.Equal(expectedItems[1].HerramientaNombre, actualItems[1].HerramientaNombre);
-            Assert.Equal(expectedItems[1].HerramientaDescripcion, actualItems[1].HerramientaDescripcion);
-            Assert.Equal(expectedItems[1].HerramientaCantidad, actualItems[1].HerramientaCantidad);
-            Assert.Equal(expectedItems[1].HerramientaPrecio, actualItems[1].HerramientaPrecio);
         }
     }
 }

--- a/test/AppForSEII2526.UT/ReparacionController_test/PostParaReparacion_test.cs
+++ b/test/AppForSEII2526.UT/ReparacionController_test/PostParaReparacion_test.cs
@@ -193,7 +193,7 @@ namespace AppForSEII2526.UT.ReparacionesController_test
                 FechaEntrega = DateOnly.FromDateTime(DateTime.Now.AddDays(2)),
                 FechaRecogida = DateOnly.FromDateTime(DateTime.Now.AddDays(4)),
                 ReparacionesItems = items
-            }; 
+            };
 
             // Act
             var result = await controller.CreateReparacion(dto);
@@ -202,17 +202,21 @@ namespace AppForSEII2526.UT.ReparacionesController_test
             var created = Assert.IsType<CreatedAtActionResult>(result);
             var reparacionDTO = Assert.IsType<ReparacionesDTO>(created.Value);
 
-            Assert.Equal(dto.Nombre, reparacionDTO.nombre);
-            Assert.Equal(dto.Apellidos, reparacionDTO.apellidos);
-            Assert.Equal(dto.ReparacionesItems.Count, reparacionDTO.ReparacionesItems.Count);
+            var expectedDTO = new ReparacionesDTO(
+                    "Fulanito",  // nombre
+                    "De Tal",    // apellidos
+                    dto.FechaEntrega,
+                    dto.FechaRecogida,
+                    90.0f, // Precio total: Taladro (50 * 1) + Martillo (20 * 2) = 90
+                    new List<ReparacionesItemDTO>
+                    {
+            new ReparacionesItemDTO("Taladro", "Sustitución de broca", 1, 50.0f),
+            new ReparacionesItemDTO("Martillo", "Cambio de mango", 2, 20.0f)
+                    }
+                );
 
-            var item1 = reparacionDTO.ReparacionesItems.FirstOrDefault(i => i.HerramientaNombre == "Taladro");
-            Assert.NotNull(item1);
-            Assert.InRange(item1.HerramientaPrecio, 49.99f, 50.01f);
+            Assert.Equal(expectedDTO, reparacionDTO);
+        }
 
-            var item2 = reparacionDTO.ReparacionesItems.FirstOrDefault(i => i.HerramientaNombre == "Martillo");
-            Assert.NotNull(item2);
-            Assert.InRange(item2.HerramientaPrecio, 19.99f, 20.01f);
         }
     }
-}


### PR DESCRIPTION
Esta rama está destinada a repara lo errores del Sprint 2: 

- Hacer que el filtro sea por nombre de herramienta y no nombre de fabricante.
- Corregir los Assert, haciéndolo mediante equals.